### PR TITLE
[src] Modification to manually do the starting setup, if the first setup fail

### DIFF
--- a/Scripts/GameMode/GameController.cs
+++ b/Scripts/GameMode/GameController.cs
@@ -89,7 +89,14 @@ namespace SofaUnityXR
             }
 
             m_SofaPlayer.stopSofaSimulation();
-            SetupSofaObject();
+            if (m_modelExplorer.m_modelElementCtrls.Count > 0)
+            {
+                SetupSofaObject();
+            }
+            else
+            {
+                Debug.LogWarning("GameController: The VR Setup of sofa object hasn't been done, must do it somewhere");
+            }
         }
 
         void Update()

--- a/Scripts/Root/SofaModelElementExplorer.cs
+++ b/Scripts/Root/SofaModelElementExplorer.cs
@@ -330,7 +330,6 @@ namespace SofaUnityXR
         /// <param name="value"></param>
         private void DetermineGrabbableElement(bool value)
         {
-            Debug.Log("Detergrabbableelem"+value);
 
             if (value)
             {

--- a/Scripts/Root/SofaModelElementExplorer.cs
+++ b/Scripts/Root/SofaModelElementExplorer.cs
@@ -6,6 +6,7 @@ using UnityEngine.UI;
 using TMPro;
 using SofaUnityXR;
 
+
 namespace SofaUnityXR
 {
     public class SofaModelElementExplorer: MonoBehaviour
@@ -329,6 +330,8 @@ namespace SofaUnityXR
         /// <param name="value"></param>
         private void DetermineGrabbableElement(bool value)
         {
+            Debug.Log("Detergrabbableelem"+value);
+
             if (value)
             {
                 m_SofaContextObj.GetComponent<XRBaseInteractable>().interactionLayers = InteractionLayerMask.GetMask("Default");

--- a/Scripts/Root/SofaModelExplorer.cs
+++ b/Scripts/Root/SofaModelExplorer.cs
@@ -51,6 +51,10 @@ namespace SofaUnityXR
             m_sliderOthers.SetValueWithoutNotify(1.0f);
 
             m_sofaContext = GameObject.Find("SofaContext");
+            if(m_sofaContext == null)
+            {
+                Debug.LogError("SofaModelExplorer: Can't find sofa context (the reaserch is made with the name sofacontext)");
+            }
             m_useURP = PiplineIsURP();
             FindRenderer();
         }
@@ -115,6 +119,7 @@ namespace SofaUnityXR
                     btn.TargetElement = obj;
                     btn.name = GetSofaName(obj);
                     btn.SetButton();
+                    btn.m_SofaContextObj = m_sofaContext.gameObject;
                     m_modelElementCtrls.Add(btn);
                 }
             }
@@ -122,11 +127,7 @@ namespace SofaUnityXR
 
 
 
-        void Update()
-        {
-           
-
-        }
+        
 
         /// <summary>
         /// select the targeted child of a the model when clicking on a button
@@ -562,6 +563,12 @@ namespace SofaUnityXR
 
             MeshRenderer[] meshRenderers = FindObjectsByType<MeshRenderer>(FindObjectsSortMode.InstanceID);
 
+            if (meshRenderers == null)
+            {
+                Debug.LogError("No SofaModelElement created");
+                return;
+            }
+
             foreach (MeshRenderer meshRenderer in meshRenderers)
             {
                 //check if it'a a child of sofa context and if the mesh renderer is active
@@ -582,6 +589,19 @@ namespace SofaUnityXR
                 current = current.parent;
             }
             return false;
+        }
+
+        public void ManualSetup()
+        {
+            if (m_modelElementCtrls.Count == 0)
+            {
+                FindRenderer();
+                Start(); 
+            } 
+            else
+            {
+                Debug.LogWarning("SofaModelExplorer: can't do Manuel setup if Setup already done");
+            }
         }
     }
 }

--- a/Scripts/Root/SofaModelExplorer.cs
+++ b/Scripts/Root/SofaModelExplorer.cs
@@ -53,7 +53,7 @@ namespace SofaUnityXR
             m_sofaContext = GameObject.Find("SofaContext");
             if(m_sofaContext == null)
             {
-                Debug.LogError("SofaModelExplorer: Can't find sofa context (the reaserch is made with the name sofacontext)");
+                Debug.LogError("SofaModelExplorer: Can't find sofa context (the search is made based on the name SofaContext)");
             }
             m_useURP = PiplineIsURP();
             FindRenderer();


### PR DESCRIPTION
Useful modification when the Sofacontext is created  during the awakening of the scene. In thoses case, sometimes sofacontext is not ready when you start the SofaUnityXR setup. So this new functions gives the possibility to call the start function again but be careful of the order.