### PR TITLE
[scripts] Add CameraSwitcherVR script to automatically detect VR is on and adapts the corresponding camera

### DIFF
--- a/Scripts/VRTools/CameraSwitcherVR.cs
+++ b/Scripts/VRTools/CameraSwitcherVR.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+using UnityEngine.XR;
+
+public class CameraSwitcherVR : MonoBehaviour
+{
+    public Camera vrCamera;
+    public Camera normalCamera;
+
+    private bool vrConnected;
+
+    void Start()
+    {
+        CheckHeadset();
+        ApplyCameraState();
+    }
+
+    void Update()
+    {
+        bool currentVRState = IsHeadsetConnected();
+        if (currentVRState != vrConnected)
+        {
+            vrConnected = currentVRState;
+            ApplyCameraState();
+        }
+    }
+
+    private void CheckHeadset()
+    {
+        vrConnected = IsHeadsetConnected();
+    }
+
+    private bool IsHeadsetConnected()
+    {
+        var xrDevices = new System.Collections.Generic.List<InputDevice>();
+        InputDevices.GetDevicesAtXRNode(XRNode.Head, xrDevices);
+        return xrDevices.Count > 0;
+    }
+
+    private void ApplyCameraState()
+    {
+        if (vrCamera == null || normalCamera == null) return;
+
+        if (vrConnected)
+        {
+            vrCamera.gameObject.SetActive(true);
+            normalCamera.gameObject.SetActive(false);
+            vrCamera.targetDisplay = 0;
+        }
+        else
+        {
+            vrCamera.gameObject.SetActive(false);
+            normalCamera.gameObject.SetActive(true);
+            normalCamera.targetDisplay = 0;
+        }
+    }
+}

--- a/Scripts/VRTools/CameraSwitcherVR.cs.meta
+++ b/Scripts/VRTools/CameraSwitcherVR.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 03a4cade79a49cc4ab2812fb08a8ff62


### PR DESCRIPTION
## Scripts/App/CameraSwitcherVR.cs 

Thanks to this script, the scenario now detects if there is a VR headset plugged in when launching the app and adapts the camera used. This script just needs to be dropped in a scene, and you need to put the two cameras as public entries in the editor.