### PR TITLE
[Prefabs] Update the name generation for sofa model explorer

### DIFF
--- a/Scripts/Root/SofaModelExplorer.cs
+++ b/Scripts/Root/SofaModelExplorer.cs
@@ -218,25 +218,48 @@ namespace SofaUnityXR
             var sofaNode = obj.GetComponent<SofaVisualModel>();
             if (sofaNode != null)
             {
-                string displayName=sofaNode.UniqueNameId;
-                int atIndex = displayName.IndexOf('@');
-                if (atIndex <= 0)
+                string displayName;
+                string UNid=sofaNode.UniqueNameId;
+                int firstIndex = UNid.IndexOf('@');
+                int lastIndex = UNid.LastIndexOf('@');
+                if (firstIndex <= 0 || lastIndex <= 0 )
                 {
                     return ("Unknown Name");
                 }
-                displayName = displayName.Substring(0, atIndex);
-                //check if there is a visu in the name
-                int visuIndex = displayName.IndexOf("visu");
-                if (visuIndex <= 0)
+
+                // we take the last string from UID
+                displayName = UNid.Substring(lastIndex+1);//
+                if (displayName == "Visual")
                 {
-                    return displayName;
+                    
+                    //if the last string if just "Visual" we take the start
+                    displayName = UNid.Substring(0, firstIndex);
+                    //check if there is a visual in the name
+                    int visuIndex = displayName.IndexOf("visual");
+                    if (visuIndex <= 0)
+                    {
+                        return displayName;
+                    }
+                    else
+                    {
+                        return displayName.Substring(0, visuIndex - 1);// -1 beacause underscore 
+                    }
                 }
                 else
                 {
-                    return  displayName.Substring(0, visuIndex-1);// -1 beacause underscore 
+                    //check if there is a visual in the name
+                    int visuIndex = displayName.IndexOf("visual");
+                    if (visuIndex <= 0)
+                    {
+                        return displayName;
+                    }
+                    else
+                    {
+                        return displayName.Substring(0, visuIndex - 1);// -1 beacause underscore 
+                    }
+                    
                 }
-               
-              
+                                 
             }
             else
             {


### PR DESCRIPTION
Update of the `GetSofaName` method in `SofaModelExplorer`, which generates names for `SofaModelElements` based on the unique ID of SOFA nodes.

The method now works correctly with both Prefabs and regular SOFA objects.

### Before
<img width="726" height="444" alt="image" src="https://github.com/user-attachments/assets/4766c122-fb6c-44af-b939-4934b6ac4f69" />

### After
<img width="592" height="451" alt="image" src="https://github.com/user-attachments/assets/ad535bd0-4682-4c03-9d7a-18aadf13a7c0" />

PR linked to this discussion:  
https://github.com/InfinyTech3D/SurgiViz4D/issues/316